### PR TITLE
Enforce maximum target comment length

### DIFF
--- a/server.js
+++ b/server.js
@@ -83,7 +83,7 @@ function processThing(model, body, id, fullname, subreddit) {
 		return;
 	}
 
-	if (!/^ugh.{0,20}/.test(model.body)) {
+	if (!/^ugh.{0,20}$/.test(model.body)) {
 		console.log("Comment too long.");
 		return;
 	}


### PR DESCRIPTION
Currently, the regex for testing maximum comment length doesn't do anything. It only checks if the "ugh" is followed by 0-20 characters, which of cause it always is.

The $ at the end of the regex enfoces that the text ends after these 20 characters. (Which seems to have been the intention)